### PR TITLE
Added 'django.contrib.staticfiles.views' to whitelisted_modules.

### DIFF
--- a/hunger/admin.py
+++ b/hunger/admin.py
@@ -12,13 +12,13 @@ invite_sent.connect(invitation_code_sent)
 
 def export_email(self, request, queryset):
     emails = ""
-    
+
     response = HttpResponse(mimetype='text/csv')
     response['Content-Disposition'] = 'attachment; filename=email.csv'
     writer = csv.writer(response)
 
     writer.writerow(["email", "is_used", "is_invited", "created", "invited", "used"])
-        
+
     for obj in queryset:
         code = obj
         email = code.email
@@ -45,47 +45,47 @@ def send_invite(self, request, queryset):
     obj = queryset[0]
     email_col = 0
     code_col = 0
-    
+
     for field in obj._meta.fields:
         if field.get_attname() == "email":
             break
         email_col = email_col + 1
-        
+
     for field in obj._meta.fields:
         if field.get_attname() == "code":
             break
         code_col = code_col + 1
-    
+
     for obj in queryset:
         email = obj._meta.fields[email_col].value_to_string(obj)
         code = obj._meta.fields[code_col].value_to_string(obj)
-        
+
         if not obj.is_invited:
             invite_sent.send(sender=self.__class__, email=email, invitation_code=code)
-            
+
 def resend_invite(self, request, queryset):
     obj = queryset[0]
     email_col = 0
     code_col = 0
-    
+
     for field in obj._meta.fields:
         if field.get_attname() == "email":
             break
         email_col = email_col + 1
-        
+
     for field in obj._meta.fields:
         if field.get_attname() == "code":
             break
         code_col = code_col + 1
-    
+
     for obj in queryset:
         email = obj._meta.fields[email_col].value_to_string(obj)
         code = obj._meta.fields[code_col].value_to_string(obj)
-        
+
         if obj.is_invited:
             invite_sent.send(sender=self.__class__, email=email, invitation_code=code)
-        
-    
+
+
 class InvitationCodeAdmin(admin.ModelAdmin):
     """Admin for invitation code"""
     #fields = ('code', 'is_used', 'is_invited', 'user', 'email', 'created', 'invited', 'used', )

--- a/hunger/middleware.py
+++ b/hunger/middleware.py
@@ -12,20 +12,20 @@ class BetaMiddleware(object):
     those in the account application require that a user be logged in.
     This can be a quick and easy way to restrict views on your site,
     particularly if you remove the ability to create accounts.
-    
+
     **Settings:**
-    
+
     ``BETA_ENABLE_BETA``
-        Whether or not the beta middleware should be used. If set to `False` 
-        the PrivateBetaMiddleware middleware will be ignored and the request 
-        will be returned. This is useful if you want to disable privatebeta 
+        Whether or not the beta middleware should be used. If set to `False`
+        the PrivateBetaMiddleware middleware will be ignored and the request
+        will be returned. This is useful if you want to disable privatebeta
         on a development machine. Default is `True`.
-    
+
     ``BETA_NEVER_ALLOW_VIEWS``
         A list of full view names that should *never* be displayed.  This
         list is checked before the others so that this middleware exhibits
         deny then allow behavior.
-    
+
     ``BETA_ALWAYS_ALLOW_VIEWS``
         A list of full view names that should always pass through.
 
@@ -34,7 +34,7 @@ class BetaMiddleware(object):
         views in ``django.contrib.auth.views``, ``django.views.static``
         and ``privatebeta.views`` will pass through unless they are
         explicitly prohibited in ``PRIVATEBETA_NEVER_ALLOW_VIEWS``
-    
+
     ``BETA_REDIRECT_URL``
         The URL to redirect to.  Can be relative or absolute.
     """
@@ -50,46 +50,50 @@ class BetaMiddleware(object):
         self.signup_url = getattr(settings, 'BETA_SIGNUP_URL', '/register/')
         self.allow_flatpages = getattr(settings, 'BETA_ALLOW_FLATPAGES', [])
 
-    def process_view(self, request, view_func, view_args, view_kwargs):        
+    def process_view(self, request, view_func, view_args, view_kwargs):
         if request.path in self.allow_flatpages or '%s/' % request.path in self.allow_flatpages:
             from django.contrib.flatpages.views import flatpage
-            return flatpage(request, request.path_info) 
-                    
+            return flatpage(request, request.path_info)
+
         if not self.enable_beta:
             #Do nothing is beta is not activated
             return
-            
+
         in_beta = request.COOKIES.get('in_beta', False)
-        whitelisted_modules = ['django.contrib.auth.views', 'django.contrib.admin.sites', 'django.views.static', 'hunger.views']            
-        
+        whitelisted_modules = ['django.contrib.auth.views',
+                               'django.contrib.admin.sites',
+                               'django.views.static',
+                               'django.contrib.staticfiles.views',
+                               'hunger.views']
+
         full_view_name = '%s.%s' % (view_func.__module__, view_func.__name__)
 
         #Check modules
         if self.always_allow_modules:
             whitelisted_modules += self.always_allow_modules
-            
+
         #if view in module then ignore - except if view is signup confirmation
         if '%s' % view_func.__module__ in whitelisted_modules and not full_view_name == self.signup_confirmation_view:
             return
-            
-        #Check views            
+
+        #Check views
         if full_view_name in self.never_allow_views:
             return HttpResponseRedirect(self.redirect_url)
 
         if full_view_name in self.always_allow_views:
             return
-        
+
         if full_view_name == self.signup_confirmation_view:
             #signup completed - deactivate invitation code
             invitation_code = request.COOKIES.get('invitation_code', None)
             request.session['beta_complete'] = True
             invite_used.send(sender=self.__class__, user=request.user, invitation_code=invitation_code)
             return
-                
+
         if request.user.is_authenticated() and full_view_name not in self.signup_views:
             # User is logged in, or beta is not active, no need to check anything else.
             return
-        
+
         if full_view_name in self.signup_views and in_beta:
             #if beta code is valid and trying to register then let them through
             return
@@ -99,8 +103,8 @@ class BetaMiddleware(object):
                 return HttpResponseRedirect(self.signup_url + '?next=%s' % next_page)
             else:
                 return HttpResponseRedirect(self.redirect_url + '?next=%s' % next_page)
-                
-    def process_response(self, request, response):      
+
+    def process_response(self, request, response):
         try:
             if request.session.get('beta_complete', False):
                 response.delete_cookie('in_beta')
@@ -109,4 +113,3 @@ class BetaMiddleware(object):
         except AttributeError:
             pass
         return response
-        

--- a/hunger/models.py
+++ b/hunger/models.py
@@ -12,14 +12,14 @@ class InvitationCode(models.Model):
     code = models.CharField(_(u"Invitation code"), blank=True, max_length=8, unique=True)
     is_used = models.BooleanField(_(u"Is Used"), default=False)
     is_invited = models.BooleanField(_('Is Invited'), default=False)
-    
+
     email = models.EmailField(_('Email address'), unique=True)
     user = models.ForeignKey(User, blank=True, null=True, default=None)
-    
+
     created = models.DateTimeField(_('Created'), auto_now_add=True)
     invited = models.DateTimeField(_(u"Invited"), blank=True, null=True)
     used = models.DateTimeField(_(u"Used"), blank=True, null=True)
-    
+
     def save(self, *args, **kwargs):
         if not self.code:
             self.code = generate_invite_code()
@@ -29,11 +29,10 @@ class InvitationCode(models.Model):
                 from hunger.signals import invite_created
                 invite_created.connect(invitation_code_created)
                 invite_created.send(sender=self.__class__, email=self.email)
-        
+
         try:
             del kwargs["skip"]
         except KeyError:
             pass
-                
+
         super(InvitationCode, self).save(*args, **kwargs)
-        

--- a/hunger/receivers.py
+++ b/hunger/receivers.py
@@ -4,10 +4,10 @@ from django.conf import settings
 from hunger.models import InvitationCode
 
 #send confirmation email to user
-def invitation_code_created(sender, email, **kwargs):    
+def invitation_code_created(sender, email, **kwargs):
     email_module = importlib.import_module(settings.BETA_EMAIL_MODULE)
     email_function = getattr(email_module, settings.BETA_EMAIL_CONFIRM_FUNCTION)
-    email_function(email)        
+    email_function(email)
 
 #send invitation code to user
 def invitation_code_sent(sender, email, invitation_code, **kwargs):
@@ -16,11 +16,11 @@ def invitation_code_sent(sender, email, invitation_code, **kwargs):
         invitation_code.is_invited = True
         invitation_code.invited = datetime.datetime.now()
         invitation_code.save()
-        
+
         email_module = importlib.import_module(settings.BETA_EMAIL_MODULE)
         email_function = getattr(email_module, settings.BETA_EMAIL_INVITE_FUNCTION)
         email_function(email, invitation_code.code)
-        
+
     except InvitationCode.DoesNotExist:
         pass
 

--- a/hunger/views.py
+++ b/hunger/views.py
@@ -26,9 +26,9 @@ def verify_invite(request, invitation_code):
 def invite(request, form_class=InviteRequestForm, template_name="beta/request_invite.html", extra_context=None):
     """
     Allow a user to request an invite at a later date by entering their email address.
-    
+
     **Arguments:**
-    
+
     ``template_name``
         The name of the tempalte to render.  Optional, defaults to
         beta/request_invite.html.
@@ -37,15 +37,15 @@ def invite(request, form_class=InviteRequestForm, template_name="beta/request_in
         A dictionary to add to the context of the view.  Keys will become
         variable names and values will be accessible via those variables.
         Optional.
-    
+
     **Context:**
-    
+
     The context will contain an ``InviteRequestForm`` that represents a
     :model:`invitemelater.InviteRequest` accessible via the variable ``form``.
     If ``extra_context`` is provided, those variables will also be accessible.
-    
+
     **Template:**
-    
+
     :template:`beta/request_invite.html` or the template name specified by
     ``template_name``.
     """
@@ -67,9 +67,9 @@ def confirmation(request, template_name="beta/confirmation.html", extra_context=
     """
     Display a message to the user after the invite request is completed
     successfully.
-    
+
     **Arguments:**
-    
+
     ``template_name``
         The name of the tempalte to render.  Optional, defaults to
         beta/confirmation.html.
@@ -78,26 +78,26 @@ def confirmation(request, template_name="beta/confirmation.html", extra_context=
         A dictionary to add to the context of the view.  Keys will become
         variable names and values will be accessible via those variables.
         Optional.
-    
+
     **Context:**
-    
+
     There will be nothing in the context unless a dictionary is passed to
     ``extra_context``.
-    
+
     **Template:**
-    
+
     :template:`beta/confirmation.html` or the template name specified by
     ``template_name``.
     """
     return direct_to_template(request, template=template_name, extra_context=extra_context)
-    
+
 
 def expired(request, template_name="beta/used.html", extra_context=None):
     """
     Display a message to the user that the invitation code has already been used.
-    
+
     **Arguments:**
-    
+
     ``template_name``
         The name of the tempalte to render.  Optional, defaults to
         beta/used.html.
@@ -106,14 +106,14 @@ def expired(request, template_name="beta/used.html", extra_context=None):
         A dictionary to add to the context of the view.  Keys will become
         variable names and values will be accessible via those variables.
         Optional.
-    
+
     **Context:**
-    
+
     There will be nothing in the context unless a dictionary is passed to
     ``extra_context``.
-    
+
     **Template:**
-    
+
     :template:`beta/used.html` or the template name specified by
     ``template_name``.
     """


### PR DESCRIPTION
The `'django.contrib.staticfiles.views'` module should be whitelisted by default. It is primarily used to serve static media like static.views. Sorry for line diffs - I was cleaning up trailing whitespace.
