### PR TITLE
Add request to email signal kwargs.

### DIFF
--- a/hunger/admin.py
+++ b/hunger/admin.py
@@ -61,7 +61,8 @@ def send_invite(self, request, queryset):
         code = obj._meta.fields[code_col].value_to_string(obj)
 
         if not obj.is_invited:
-            invite_sent.send(sender=self.__class__, email=email, invitation_code=code)
+            invite_sent.send(sender=self.__class__, email=email,
+                             invitation_code=code, request=request)
 
 def resend_invite(self, request, queryset):
     obj = queryset[0]
@@ -83,7 +84,8 @@ def resend_invite(self, request, queryset):
         code = obj._meta.fields[code_col].value_to_string(obj)
 
         if obj.is_invited:
-            invite_sent.send(sender=self.__class__, email=email, invitation_code=code)
+            invite_sent.send(sender=self.__class__, email=email,
+                             invitation_code=code, request=request)
 
 
 class InvitationCodeAdmin(admin.ModelAdmin):

--- a/hunger/receivers.py
+++ b/hunger/receivers.py
@@ -7,7 +7,7 @@ from hunger.models import InvitationCode
 def invitation_code_created(sender, email, **kwargs):
     email_module = importlib.import_module(settings.BETA_EMAIL_MODULE)
     email_function = getattr(email_module, settings.BETA_EMAIL_CONFIRM_FUNCTION)
-    email_function(email)
+    email_function(email, **kwargs)
 
 #send invitation code to user
 def invitation_code_sent(sender, email, invitation_code, **kwargs):
@@ -19,7 +19,7 @@ def invitation_code_sent(sender, email, invitation_code, **kwargs):
 
         email_module = importlib.import_module(settings.BETA_EMAIL_MODULE)
         email_function = getattr(email_module, settings.BETA_EMAIL_INVITE_FUNCTION)
-        email_function(email, invitation_code.code)
+        email_function(email, invitation_code.code, **kwargs)
 
     except InvitationCode.DoesNotExist:
         pass


### PR DESCRIPTION
We should add request to the email signals. Therefore we can do things request.get_host() to automatically detect which domain the invites are being sent from. This is especailly useful for testing on a development machine where the domain would be localhost instead of the deployment machine, and we can send invites with a link to the dev link instead of the deployed link.
