### PR TITLE
Use sessions instead of cookies for security.

### DIFF
--- a/hunger/middleware.py
+++ b/hunger/middleware.py
@@ -59,7 +59,7 @@ class BetaMiddleware(object):
             #Do nothing is beta is not activated
             return
 
-        in_beta = request.COOKIES.get('in_beta', False)
+        in_beta = request.session.get('in_beta', False)
         whitelisted_modules = ['django.contrib.auth.views',
                                'django.contrib.admin.sites',
                                'django.views.static',
@@ -85,7 +85,7 @@ class BetaMiddleware(object):
 
         if full_view_name == self.signup_confirmation_view:
             #signup completed - deactivate invitation code
-            invitation_code = request.COOKIES.get('invitation_code', None)
+            invitation_code = request.session.get('invitation_code', None)
             request.session['beta_complete'] = True
             invite_used.send(sender=self.__class__, user=request.user, invitation_code=invitation_code)
             return
@@ -107,8 +107,8 @@ class BetaMiddleware(object):
     def process_response(self, request, response):
         try:
             if request.session.get('beta_complete', False):
-                response.delete_cookie('in_beta')
-                response.delete_cookie('invitation_code')
+                del response.session['in_beta']
+                del response.session['invitation_code']
                 request.session['beta_complete'] = None
         except AttributeError:
             pass

--- a/hunger/views.py
+++ b/hunger/views.py
@@ -15,8 +15,8 @@ def verify_invite(request, invitation_code):
         else:
             url = getattr(settings, 'BETA_SIGNUP_URL', '/signup/')
             response = redirect(url)
-            response.set_cookie('in_beta', True)
-            response.set_cookie('invitation_code', invitation_code.code)
+            response.session.setdefault('in_beta', True)
+            response.session.setdefault('invitation_code', invitation_code.code)
             return response
     except InvitationCode.DoesNotExist:
         url = getattr(settings, 'BETA_REDIRECT_URL', '/beta/')


### PR DESCRIPTION
Here is a preliminary change using sessions instead of cookies. With the previous method using cookies. Anybody can join the beta by changing their cookies. See #3.
