### PR TITLE
Reasonable defaults for email sending.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Settings
 ``BETA_ALWAYS_ALLOW_VIEWS``
     Always let unregistered user see these view
 ``BETA_ALWAYS_ALLOW_MODULES``
-    Convenience settings - allow all views and a given module 
+    Convenience settings - allow all views and a given module
 ``BETA_ALLOW_FLATPAGES``
     If using flatpages app
 ``BETA_SIGNUP_VIEWS``
@@ -39,6 +39,8 @@ Settings
     If user is not logged in and trying to access a hidden view - where should he/she be redirected
 ``BETA_SIGNUP_URL``
     What is the url for the signup page
+``BETA_EMAIL_TEMPLATES_DIR``
+    Directory containing email templates
 ``BETA_EMAIL_MODULE``
     Module where the email functions are
 ``BETA_EMAIL_CONFIRM_FUNCTION``

--- a/hunger/email.py
+++ b/hunger/email.py
@@ -1,0 +1,46 @@
+import os.path
+from django.core.mail import EmailMultiAlternatives
+from django.template.loader import get_template
+from django.template import Context
+from hunger.utils import setting
+
+def beta_confirm(email, **kwargs):
+    """
+    Send out email confirming that they requested an invite.
+    """
+
+    templates_folder = setting('BETA_EMAIL_TEMPLATES_DIR', 'hunger')
+    plaintext = get_template(os.path.join(templates_folder, 'beta_confirm.txt'))
+    html = get_template(os.path.join(templates_folder, 'beta_confirm.html'))
+
+    from_email = setting('EMAIL_HOST_USER')
+    subject, to = 'You requested an invite!', email
+    text_content = plaintext.render(Context())
+    html_content = html.render(Context())
+    msg = EmailMultiAlternatives(subject, text_content, from_email, [to],
+                                 headers={'From': 'Mailer <%s>' % from_email})
+    msg.attach_alternative(html_content, "text/html")
+    msg.send()
+
+def beta_invite(email, code, **kwargs):
+    """
+    Email for sending out the invitation code to the user.
+    Invitation code is added to the context, so it can be rendered with standard
+    django template engine.
+    """
+    context_dict = kwargs.copy()
+    context_dict.setdefault('code', code)
+    context = Context(context_dict)
+
+    templates_folder = setting('BETA_EMAIL_TEMPLATES_DIR', 'hunger')
+    plaintext = get_template(os.path.join(templates_folder, 'beta_invite.txt'))
+    html = get_template(os.path.join(templates_folder, 'beta_invite.html'))
+
+    from_email = setting('EMAIL_HOST_USER')
+    subject, to = "Here is your invite", email
+    text_content = plaintext.render(context)
+    html_content = html.render(context)
+    msg = EmailMultiAlternatives(subject, text_content, from_email, [to],
+                                 headers={'From': 'Mailer <%s>' % from_email})
+    msg.attach_alternative(html_content, "text/html")
+    msg.send()

--- a/hunger/receivers.py
+++ b/hunger/receivers.py
@@ -1,36 +1,44 @@
 import datetime
 import importlib
-from django.conf import settings
 from hunger.models import InvitationCode
+from hunger.utils import setting
 
-#send confirmation email to user
+
 def invitation_code_created(sender, email, **kwargs):
-    email_module = importlib.import_module(settings.BETA_EMAIL_MODULE)
-    email_function = getattr(email_module, settings.BETA_EMAIL_CONFIRM_FUNCTION)
+    """Send confirmation email to user."""
+    email_module_name = setting('BETA_EMAIL_MODULE', 'hunger.email')
+    email_module = importlib.import_module(email_module_name)
+    email_function_name = setting('BETA_EMAIL_CONFIRM_FUNCTION', 'beta_confirm')
+    email_function = getattr(email_module, email_function_name)
     email_function(email, **kwargs)
 
-#send invitation code to user
+
 def invitation_code_sent(sender, email, invitation_code, **kwargs):
+    """Send invitation code to user."""
     try:
         invitation_code = InvitationCode.objects.get(email=email)
-        invitation_code.is_invited = True
-        invitation_code.invited = datetime.datetime.now()
-        invitation_code.save()
-
-        email_module = importlib.import_module(settings.BETA_EMAIL_MODULE)
-        email_function = getattr(email_module, settings.BETA_EMAIL_INVITE_FUNCTION)
-        email_function(email, invitation_code.code, **kwargs)
-
     except InvitationCode.DoesNotExist:
-        pass
+        return
 
-#when user with corresponding email has been created then set the code as used.
+    invitation_code.is_invited = True
+    invitation_code.invited = datetime.datetime.now()
+    invitation_code.save()
+
+    email_module_name = setting('BETA_EMAIL_MODULE', 'hunger.email')
+    email_module = importlib.import_module(email_module_name)
+    email_function_name = setting('BETA_EMAIL_INVITE_FUNCTION', 'beta_invite')
+    email_function = getattr(email_module, email_function_name)
+    email_function(email, invitation_code.code, **kwargs)
+
+
 def invitation_code_used(sender, user, invitation_code, **kwargs):
+    """Set the invitation code as used by user."""
     try:
         invitation_code = InvitationCode.objects.get(code=invitation_code)
-        invitation_code.user = user
-        invitation_code.is_used = True
-        invitation_code.used = datetime.datetime.now()
-        invitation_code.save()
     except InvitationCode.DoesNotExist:
-        pass
+        return
+
+    invitation_code.user = user
+    invitation_code.is_used = True
+    invitation_code.used = datetime.datetime.now()
+    invitation_code.save()

--- a/hunger/templates/hunger/beta_confirm.html
+++ b/hunger/templates/hunger/beta_confirm.html
@@ -1,0 +1,3 @@
+We have received your request for invite to the private beta.
+We'll contact you as soon as we are ready!
+

--- a/hunger/templates/hunger/beta_confirm.txt
+++ b/hunger/templates/hunger/beta_confirm.txt
@@ -1,0 +1,2 @@
+We have received your request for invite to the private beta.
+We'll contact you as soon as we are ready!

--- a/hunger/templates/hunger/beta_invite.html
+++ b/hunger/templates/hunger/beta_invite.html
@@ -1,0 +1,1 @@
+Visit <a href="{{ request.get_host }}/invites/verify/{{ code }}/" target="_blank">{{ request.get_host }}/invites/verify/{{ code }}/</a> to join the private beta.

--- a/hunger/templates/hunger/beta_invite.txt
+++ b/hunger/templates/hunger/beta_invite.txt
@@ -1,0 +1,1 @@
+Visit {{ request.get_host }}/invites/verify/{{ code }}/ to join the private beta.

--- a/hunger/urls.py
+++ b/hunger/urls.py
@@ -3,5 +3,6 @@ from django.conf.urls.defaults import *
 urlpatterns = patterns('',
     url(r'^$', 'hunger.views.invite', name='beta_invite'),
     url(r'^sent', 'hunger.views.confirmation', name='beta_confirmation'),
+    url(r'^verify/(\w+)/$', 'hunger.views.verify_invite'),
     url(r'^expired', 'hunger.views.expired', name='beta_used'),
 )

--- a/hunger/utils.py
+++ b/hunger/utils.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+def setting(name, default=None):
+    """Return setting value for given name or default value."""
+    return getattr(settings, name, default)


### PR DESCRIPTION
Some reasonable defaults for email sending and invite verification so users don't have to write a custom url or specify `EMAIL_MODULE` / `EMAIL_FUNCTION` for out of the box functionality. Addresses #6.
