### PR TITLE
Include templates in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+recursive-include hunger/templates *


### PR DESCRIPTION
The templates aren't included in a typical install since they are HTML files. I've included them in  the MANIFEST.in file so they get installed as well.
