### PR TITLE
Add protocol to URLs in invitation emails.

### DIFF
--- a/hunger/email.py
+++ b/hunger/email.py
@@ -1,5 +1,6 @@
 import os.path
 from django.core.mail import EmailMultiAlternatives
+from django.core.urlresolvers import reverse
 from django.template.loader import get_template
 from django.template import Context
 from hunger.utils import setting
@@ -44,14 +45,17 @@ def beta_confirm(email, **kwargs):
         msg.attach_alternative(html_content, "text/html")
         msg.send()
 
-def beta_invite(email, code, **kwargs):
+def beta_invite(email, code, request, **kwargs):
     """
     Email for sending out the invitation code to the user.
-    Invitation code is added to the context, so it can be rendered with standard
+    Invitation URL is added to the context, so it can be rendered with standard
     django template engine.
     """
     context_dict = kwargs.copy()
-    context_dict.setdefault('code', code)
+    context_dict.setdefault(
+        "invite_url",
+        request.build_absolute_uri(reverse("beta_verify_invite", args=[code]))
+    )
     context = Context(context_dict)
 
     templates_folder = setting('BETA_EMAIL_TEMPLATES_DIR', 'hunger')

--- a/hunger/templates/hunger/beta_invite.email
+++ b/hunger/templates/hunger/beta_invite.email
@@ -1,9 +1,9 @@
 {% block subject %}Here is your invite{% endblock %}
 
 {% block plain %}
-  Visit {{ request.get_host }}{% url beta_verify_invite code %} to join the private beta.
+  Visit {{ invite_url }} to join the private beta.
 {% endblock %}
 
 {% block html %}
-  Visit <a href="{{ request.get_host }}{% url beta_verify_invite code %}" target="_blank">{{ request.get_host }}{% url beta_verify_invite code %}</a> to join the private beta.
+  Visit <a href="{{ invite_url }}" target="_blank">{{ invite_url }}</a> to join the private beta.
 {% endblock %}

--- a/hunger/templates/hunger/beta_invite.html
+++ b/hunger/templates/hunger/beta_invite.html
@@ -1,1 +1,1 @@
-Visit <a href="{{ request.get_host }}{% url beta_verify_invite code %}" target="_blank">{{ request.get_host }}{% url beta_verify_invite code %}</a> to join the private beta.
+Visit <a href="{{ invite_url }}" target="_blank">{{ invite_url }}</a> to join the private beta.

--- a/hunger/templates/hunger/beta_invite.txt
+++ b/hunger/templates/hunger/beta_invite.txt
@@ -1,1 +1,1 @@
-Visit {{ request.get_host }}{% url beta_verify_invite code %} to join the private beta.
+Visit {{ invite_url }} to join the private beta.


### PR DESCRIPTION
Use Django's `request.build_absolute_uri` to construct absolute URLs,
since `request.get_host` does not include protocols (http:// or
https://). This causes clients that only support plain text or strict
HTML to fail to parse the invitation URL.
