### PR TITLE
Update pipeline for django-social-auth 0.7.9.

### DIFF
--- a/hunger/contrib/social_auth_pipeline.py
+++ b/hunger/contrib/social_auth_pipeline.py
@@ -23,7 +23,7 @@ def create_beta_user(backend, details, response, uid, username, user=None,
             return HttpResponseRedirect(setting('BETA_REDIRECT_URL'))
 
     email = details.get('email')
-    user = UserSocialAuth.objects.create_user(username=username, email=email)
+    user = UserSocialAuth.create_user(username=username, email=email)
     if setting('BETA_ENABLE_BETA', True):
         invite_used.send(sender=user, user=user, invitation_code=invitation_code)
 


### PR DESCRIPTION
An update in django-social-auth (possibly omab/django-social-auth@d6e97316138aed9bac23409e2b2f688a75cce50c?)
breaks django-hunger's social auth pipeline by changing the location of
the `create_user` method.
