### PR TITLE
Add BETA_ALWAYS_ALLOW_URLS to allow url patterns

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,8 @@ Settings
     Always let unregistered user see these view (Default: ``[]``)
 ``BETA_ALWAYS_ALLOW_MODULES``
     Convenience settings - allow all views and a given module (Default: ``[]``)
+``BETA_ALWAYS_ALLOW_URLS``
+    Always let unregistered users see pages matching these urls (can also be regular expressions) (Default: ``[]``)
 ``BETA_ALLOW_FLATPAGES``
     If using flatpages app (Default: ``[]``)
 ``BETA_SIGNUP_VIEWS``

--- a/hunger/middleware.py
+++ b/hunger/middleware.py
@@ -1,3 +1,5 @@
+import re
+
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from hunger.models import InvitationCode
@@ -36,6 +38,9 @@ class BetaMiddleware(object):
         and ``privatebeta.views`` will pass through unless they are
         explicitly prohibited in ``PRIVATEBETA_NEVER_ALLOW_VIEWS``
 
+    ``BETA_ALWAYS_ALLOW_URLS``
+        A list of regex matching urls that should pass through.
+
     ``BETA_REDIRECT_URL``
         The URL to redirect to.  Can be relative or absolute.
     """
@@ -45,6 +50,7 @@ class BetaMiddleware(object):
         self.never_allow_views = getattr(settings, 'BETA_NEVER_ALLOW_VIEWS', [])
         self.always_allow_views = getattr(settings, 'BETA_ALWAYS_ALLOW_VIEWS', [])
         self.always_allow_modules = getattr(settings, 'BETA_ALWAYS_ALLOW_MODULES', [])
+        self.always_allow_urls = getattr(settings, 'BETA_ALWAYS_ALLOW_URLS', [])
         self.redirect_url = getattr(settings, 'BETA_REDIRECT_URL', '/beta/')
         self.signup_views = getattr(settings, 'BETA_SIGNUP_VIEWS', [])
         self.signup_confirmation_view = getattr(settings, 'BETA_SIGNUP_CONFIRMATION_VIEW', '')
@@ -86,6 +92,9 @@ class BetaMiddleware(object):
             return HttpResponseRedirect(self.redirect_url)
 
         if full_view_name in self.always_allow_views:
+            return
+
+        if any(re.match(regex, request.path) for regex in self.always_allow_urls):
             return
 
         if full_view_name == self.signup_confirmation_view:

--- a/runtests.py
+++ b/runtests.py
@@ -46,6 +46,7 @@ if not settings.configured:
         BETA_ALWAYS_ALLOW_VIEWS=[
             'tests.views.always_allow',
         ],
+        BETA_ALWAYS_ALLOW_URLS=['/always-allow-url/'],
         BETA_REDIRECT_URL='/',
         BETA_ALWAYS_ALLOW_MODULES=['tests.always_allow_views'],
         BETA_SIGNUP_VIEWS=['tests.views.signup'],

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -38,6 +38,10 @@ class BetaViewTests(TestCase):
         response = self.client.get(reverse('always_allow_module'))
         self.assertEqual(response.status_code, 200)
 
+    def test_always_allow_url(self):
+        response = self.client.get(reverse('always_allow_url'))
+        self.assertEqual(response.status_code, 200)
+
     def test_garden_when_not_logged_in(self):
         response = self.client.get(reverse('logged_in_only'))
         self.assertRedirects(response,

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls.defaults import *
 from django.views.generic.simple import direct_to_template
+from django.views.generic import TemplateView
 
 
 urlpatterns = patterns('',
@@ -9,6 +10,8 @@ urlpatterns = patterns('',
     url(r'^always-allow/$', 'tests.views.always_allow', name='always_allow'),
     url(r'^always-allow-module/$', 'tests.always_allow_views.allowed',
         name='always_allow_module'),
+    url(r'^always-allow-url/$', TemplateView.as_view(template_name='default.html'),
+        name='always_allow_url'),
     url(r'^beta/$', direct_to_template,
         {'template': 'default.html'}, name='not_allowed_redirect'),
     url(r'^register/$', 'tests.views.signup', name='register'),


### PR DESCRIPTION
With this settings it is possible to allow all the requests on urls matching a list of regular expressions, enabling us to do something like:

```
BETA_ALWAYS_ALLOW_URLS = ['/accounts/*', ]
```

which will enable all the views about login, logout, registration and password reset/change.
