### PR TITLE
beta_invite email context: Use sites framework

### DIFF
--- a/hunger/email.py
+++ b/hunger/email.py
@@ -31,10 +31,11 @@ def beta_invite(email, code, request, **kwargs):
     context_dict.setdefault("site", site)
     context_dict.setdefault("code", code)
 
-    context_dict.setdefault(
-        "invite_url",
-        request.build_absolute_uri(reverse("hunger-verify", args=[code]))
-    )
+    if request:
+        context_dict.setdefault(
+            "invite_url",
+            request.build_absolute_uri(reverse("hunger-verify", args=[code]))
+        )
     context = Context(context_dict)
 
     templates_folder = setting('HUNGER_EMAIL_TEMPLATES_DIR')


### PR DESCRIPTION
This contains one fix and one improvement:

(1) Uses `Site.objects.get_current()` to build the invitation verify url when sending emails. This is done in a similar fashion to how django-registration does it.

This is needed if the admin site and the production site have different domains.

(2) I found an old reference to the named url pattern `beta_invite_url` (that's the only occurrence, I grepped the whole repo), which I updated.
