### PR TITLE
Allow InvitationCode.code to be auto generated

### DIFF
--- a/hunger/models.py
+++ b/hunger/models.py
@@ -28,7 +28,7 @@ class Invitation(models.Model):
 
 
 class InvitationCode(models.Model):
-    code = models.CharField(_('Invitation code'), max_length=30, unique=True)
+    code = models.CharField(_('Invitation code'), max_length=30, unique=True, blank=True)
     private = models.BooleanField(default=True)
     max_invites = models.PositiveIntegerField(
         _('Max number of invitations'), default=1)


### PR DESCRIPTION
There is python code at https://github.com/joshuakarjala/django-hunger/blob/master/hunger/models.py#L53 that auto-generates invite codes, but because the CharField is not `blank=True` this is never executed because model validation fails before reaching that point.
