### PR TITLE
email subject: strip leading and trailing newlines

### DIFF
--- a/hunger/email.py
+++ b/hunger/email.py
@@ -47,7 +47,7 @@ def beta_invite(email, code, request, **kwargs):
         html = get_template(os.path.join(templates_folder, 'invite_email.html'))
 
         subject = get_template(os.path.join(templates_folder,
-            'invite_email_subject.txt')).render(context)
+            'invite_email_subject.txt')).render(context).strip("\n")
         to = email
         text_content = plaintext.render(context)
         html_content = html.render(context)


### PR DESCRIPTION
Error was:
### Header values can't contain newlines (got u'Your invitation is ready\n' for header u'Subject')
