### PR TITLE
Django 1.7 compatibility 

### DIFF
--- a/hunger/models.py
+++ b/hunger/models.py
@@ -8,12 +8,16 @@ from django.utils.translation import ugettext_lazy as _
 from hunger.utils import setting
 
 try:
-    from django.contrib.auth import get_user_model
-    User = get_user_model()
-except RuntimeError:
+    from django.core.exceptions import AppRegistryNotReady
     User = settings.AUTH_USER_MODEL
 except ImportError:
-    from django.contrib.auth.models import User
+    try:
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+    except RuntimeError:
+        User = settings.AUTH_USER_MODEL
+    except ImportError:
+        from django.contrib.auth.models import User
 
 
 class Invitation(models.Model):


### PR DESCRIPTION
get_user_model is leading to problems in Django 1.7 if the app registry is not fully populated (e.g. at import time).

See: https://docs.djangoproject.com/en/dev/ref/applications/#troubleshooting
