### PR TITLE
Django1.7

### DIFF
--- a/hunger/models.py
+++ b/hunger/models.py
@@ -8,12 +8,16 @@ from django.utils.translation import ugettext_lazy as _
 from hunger.utils import setting
 
 try:
-    from django.contrib.auth import get_user_model
-    User = get_user_model()
-except RuntimeError:
+    from django.core.exceptions import AppRegistryNotReady
     User = settings.AUTH_USER_MODEL
 except ImportError:
-    from django.contrib.auth.models import User
+    try:
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+    except RuntimeError:
+        User = settings.AUTH_USER_MODEL
+    except ImportError:
+        from django.contrib.auth.models import User
 
 
 class Invitation(models.Model):


### PR DESCRIPTION
Fails with Django 1.7 because of use of User = get_user_model() at the module level. This results in a AppRegistryNotReady exception.
