### PR TITLE
Make sure invitation has a code before trying to access it

### DIFF
--- a/hunger/middleware.py
+++ b/hunger/middleware.py
@@ -112,7 +112,7 @@ class BetaMiddleware(object):
         # Check for matching cookie code if available.
         if cookie_code:
             for invitation in activates:
-                if invitation.code.code == cookie_code:
+                if invitation.code and invitation.code.code == cookie_code:
                     # Invitation may be attached to email
                     invitation.user = request.user
                     invitation.used = now()


### PR DESCRIPTION
I'm not sure how I managed to hit a condition in which there was an invitation without a code but I did. Perhaps checking for existence is a good idea?
