### PR TITLE
Update URL to resolve RemovedInDjango110Warning

### DIFF
--- a/hunger/urls.py
+++ b/hunger/urls.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from .views import (InviteView, VerifiedView, InvalidView, NotBetaView,
                     InviteSentView, verify_invite)
 

--- a/hunger/urls.py
+++ b/hunger/urls.py
@@ -1,17 +1,14 @@
 from __future__ import unicode_literals
 from django.conf.urls import patterns, url
 from .views import (InviteView, VerifiedView, InvalidView, NotBetaView,
-                    InviteSentView)
+                    InviteSentView, verify_invite)
 
 
-urlpatterns = patterns(
-    '',
-    url(r'^verify/(\w+)/$', 'hunger.views.verify_invite',
-        name='hunger-verify'),
+urlpatterns = [
+    url(r'^verify/(\w+)/$', verify_invite, name='hunger-verify'),
     url(r'^invite/$', InviteView.as_view(), name='hunger-invite'),
     url(r'^sent/$', InviteSentView.as_view(), name='hunger-invite-sent'),
     url(r'^not-in-beta/$', NotBetaView.as_view(), name='hunger-not-in-beta'),
     url(r'^verified/$', VerifiedView.as_view(), name='hunger-verified'),
-    url(r'^invalid/(?P<code>\w+)/$', InvalidView.as_view(),
-        name='hunger-invalid'),
-)
+    url(r'^invalid/(?P<code>\w+)/$', InvalidView.as_view(), name='hunger-invalid'),
+]


### PR DESCRIPTION
RemovedInDjango110Warning: Support for string view arguments to url() is deprecated and will be removed in Django 1.10 (got hunger.views.verify_invite). Pass the callable instead.
  name='hunger-verify'),

RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  name='hunger-invalid'),
