### PR TITLE
Redirect to login will now pass "next" argument. 

### DIFF
--- a/hunger/middleware.py
+++ b/hunger/middleware.py
@@ -86,7 +86,10 @@ class BetaMiddleware(object):
 
         if not request.user.is_authenticated():
             # Ask anonymous user to log in if trying to access in-beta view
-            return redirect(setting('LOGIN_URL'))
+            # This is based on user_passes_test internal django function
+            path = request.get_full_path()
+            from django.contrib.auth.views import redirect_to_login
+            return redirect_to_login(path)
 
         if request.user.is_staff:
             return

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -60,7 +60,7 @@ class BetaViewTests(TestCase):
         Confirm that an unauthenticated user is redirected to login.
         """
         response = self.client.get(reverse('invited_only'))
-        self.assertRedirects(response, setting('LOGIN_URL'))
+        self.assertRedirects(response, setting('LOGIN_URL')+"?next=/invited-only/")
 
     def test_using_invite(self):
         cary = User.objects.create_user('cary', 'cary@example.com', 'secret')
@@ -128,7 +128,7 @@ class BetaViewTests(TestCase):
         response = self.client.get(reverse('hunger-verify',
                                            args=[code.code]), follow=True)
         # Anonymous user cannot verify a private InvitationCode
-        self.assertRedirects(response, setting('LOGIN_URL'))
+        self.assertRedirects(response, setting('LOGIN_URL')+"?next=/hunger/verified/")
 
         User.objects.create_user('dany', 'dany@example.com', 'secret')
         self.client.login(username='dany', password='secret')
@@ -149,7 +149,7 @@ class BetaViewTests(TestCase):
                                            args=[code.code]), follow=True)
 
         response = self.client.get(reverse('invited_only'))
-        self.assertRedirects(response, setting('LOGIN_URL'))
+        self.assertRedirects(response, setting('LOGIN_URL')+"?next=/invited-only/")
 
         User.objects.create_user('dany', 'dany@example.com', 'secret')
         self.client.login(username='dany', password='secret')
@@ -166,7 +166,7 @@ class BetaViewTests(TestCase):
         response = self.client.get(reverse('hunger-verify',
                                            args=[code.code]), follow=True)
         # Anonymous user cannot verify a private InvitationCode
-        self.assertRedirects(response, setting('LOGIN_URL'))
+        self.assertRedirects(response, setting('LOGIN_URL')+"?next=/hunger/verified/")
 
         self.client.login(username='alice', password='secret')
         response = self.client.get(reverse('invited_only'))


### PR DESCRIPTION
When logged in user When logged in, user will return to the requested page instead of root.
